### PR TITLE
tn-ro: fix type and property names in Groovy script

### DIFF
--- a/projects/tn-ro-manual.diff
+++ b/projects/tn-ro-manual.diff
@@ -1,5 +1,5 @@
 diff --git a/projects/tn-ro-auto.halex.alignment.xml b/projects/tn-ro-manual.halex.alignment.xml
-index 33dbb0d..04a5866 100644
+index 33dbb0d..23cc337 100644
 --- a/projects/tn-ro-auto.halex.alignment.xml
 +++ b/projects/tn-ro-manual.halex.alignment.xml
 @@ -64,11 +64,22 @@ Nur erfolgreich falls genau eine Simple Feature Geometrie gebildet werden kann.
@@ -780,15 +780,37 @@ index 33dbb0d..04a5866 100644
  case '1301': // Bundesautobahn
  	functionalClass = 'firstClass'
  	break
-@@ -3819,7 +3891,7 @@ if (_source.p.internationaleBedeutung.value() == '2001') {
+@@ -3810,24 +3882,24 @@ case '1307': // Gemeindestraße
+ 	functionalClass = 'sixthClass'
+ 	break
+ }
+-if (_source.p.internationaleBedeutung.value() == '2001') {
++if (_source.p.internationalebedeutung.value() == '2001') {
+ 	// internationaleBedeutung "überstimmt" Widmung
+ 	functionalClass = 'mainRoad'
+ }
+ 
+ // Hilfsfunktion zum Erstellen eines RoadLink aus einer *achse
  def erstelleRoadLink = { achse -&gt;
- 	boolean istFahrbahn = achse.definition.name.localPart.startsWith('AX_Fahrbahn')
+-	boolean istFahrbahn = achse.definition.name.localPart.startsWith('AX_Fahrbahn')
++	boolean istFahrbahn = achse.definition.name.localPart.startsWith('ax_fahrbahn')
  
 -	def sourceId = achse.p.id.value()
 +	def sourceId = achse.p.gml_id.value()
  	def _id = "RoadLink_$sourceId"
  	def _ns = _project.vars.INSPIRE_NAMESPACE
  	
+ 	_target {
+-		endLifespanVersion( achse.p.lebenszeitintervall.AA_Lebenszeitintervall.endet.value() )
+-		beginLifespanVersion( achse.p.lebenszeitintervall.AA_Lebenszeitintervall.beginnt.value() )
++		endLifespanVersion( achse.p.endet.value() )
++		beginLifespanVersion( achse.p.beginnt.value() )
+ 		id( _id )
+-		def geoms = _.geom.toSimpleGeometries(geometries: achse.p.position.first(), collections: false)
++		def geoms = _.geom.toSimpleGeometries(geometries: achse.p.wkb_geometry.value(), collections: false)
+ 		if (geoms.size() &gt; 1) {
+ 			_log.error("Zusammenfassung von Geometrie in Achse ${sourceId} nicht möglich")
+ 		}
 @@ -3846,22 +3918,22 @@ def erstelleRoadLink = { achse -&gt;
  		
  		// bestimme FormOfWay

--- a/projects/tn-ro-manual.halex
+++ b/projects/tn-ro-manual.halex
@@ -24,7 +24,7 @@ Im Projekt gibt es drei verschiedene Herangehensweisen zur Bildung von *Transpor
 2. Ein *TransportProperty*-Objekt für alle Features die in den Quell-Daten die gleichen relevanten Informationen aufweisen. Die Identifier werden dabei basierend auf dem Quell-Wert oder -Werten gebildet. Umgesetzt wurde das so für `RoadServiceType`.
 3. Ein *TransportProperty*-Objekt für jedes Feature dass über entsprechende Eigenschaften verfügt. Dabei gibt es ggf. sehr viele redundante Informationen in den Objekten. Umgesetzt wurde das so für `RoadWidth`.</description>
     <created>2015-09-28T11:46:45.435+02:00</created>
-    <modified>2022-01-04T16:40:07.803+01:00</modified>
+    <modified>2022-01-10T14:59:06.419+01:00</modified>
     <save-config provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/projects/tn-ro-manual.halex.alignment.xml
+++ b/projects/tn-ro-manual.halex.alignment.xml
@@ -3882,24 +3882,24 @@ case '1307': // Gemeindestraße
 	functionalClass = 'sixthClass'
 	break
 }
-if (_source.p.internationaleBedeutung.value() == '2001') {
+if (_source.p.internationalebedeutung.value() == '2001') {
 	// internationaleBedeutung "überstimmt" Widmung
 	functionalClass = 'mainRoad'
 }
 
 // Hilfsfunktion zum Erstellen eines RoadLink aus einer *achse
 def erstelleRoadLink = { achse -&gt;
-	boolean istFahrbahn = achse.definition.name.localPart.startsWith('AX_Fahrbahn')
+	boolean istFahrbahn = achse.definition.name.localPart.startsWith('ax_fahrbahn')
 
 	def sourceId = achse.p.gml_id.value()
 	def _id = "RoadLink_$sourceId"
 	def _ns = _project.vars.INSPIRE_NAMESPACE
 	
 	_target {
-		endLifespanVersion( achse.p.lebenszeitintervall.AA_Lebenszeitintervall.endet.value() )
-		beginLifespanVersion( achse.p.lebenszeitintervall.AA_Lebenszeitintervall.beginnt.value() )
+		endLifespanVersion( achse.p.endet.value() )
+		beginLifespanVersion( achse.p.beginnt.value() )
 		id( _id )
-		def geoms = _.geom.toSimpleGeometries(geometries: achse.p.position.first(), collections: false)
+		def geoms = _.geom.toSimpleGeometries(geometries: achse.p.wkb_geometry.value(), collections: false)
 		if (geoms.size() &gt; 1) {
 			_log.error("Zusammenfassung von Geometrie in Achse ${sourceId} nicht möglich")
 		}


### PR DESCRIPTION
Adapt an occurence of the type name `AX_Fahrbahn` as well as references to the
`gml_id`, `lebenszeitintervall`, `internationalebedeutung` and `position`
properties to the PostNAS schema.

WGS-1377