### PR TITLE
refactor: disable generation of LandCoverDataSet members

### DIFF
--- a/projects/lc-auto.halex
+++ b/projects/lc-auto.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="5.1.0.release">
+<hale-project version="5.3.0.release">
     <name>[Annex II] AdV ALKIS 7.1.2 zu INSPIRE Land Cover</name>
     <author>Johanna Ott</author>
     <description>Transformationsprojekt für die Transformation von Daten aus ALKIS nach INSPIRE LandCover.&#13;
@@ -12,7 +12,7 @@ Hinweis zur Nutzung der Projektvariablen:&#13;
 	LANDCOVER_DATASET: id des LandCoverDatasets --&gt; kann nach Wunsch verändert werden&#13;
 	INSPIRE_NAMESPACE: gewünschten Namespace eingeben</description>
     <created>2018-02-21T09:31:57.934+01:00</created>
-    <modified>2024-04-25T16:31:13.819+02:00</modified>
+    <modified>2024-09-11T11:24:54.080+02:00</modified>
     <save-config provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/projects/lc-manual.diff
+++ b/projects/lc-manual.diff
@@ -1,5 +1,5 @@
 diff --git a/projects/lc-auto.halex.alignment.xml b/projects/lc-manual.halex.alignment.xml
-index e0d5ce6..5d2db35 100644
+index e0d5ce6..f0ad000 100644
 --- a/projects/lc-auto.halex.alignment.xml
 +++ b/projects/lc-manual.halex.alignment.xml
 @@ -64,11 +64,22 @@ Nur erfolgreich falls genau eine Simple Feature Geometrie gebildet werden kann.
@@ -779,3 +779,11 @@ index e0d5ce6..5d2db35 100644
                  <core:content>
                      <core:text xml:space="preserve">Filter condition may not be valid because the entity it is applied to has been replaced</core:text>
                  </core:content>
+@@ -14036,4 +14046,7 @@ return targeom
+         </target>
+         <parameter value="other:unpopulated" name="value"/>
+     </cell>
++    <modifier cell="C291e909f-6406-4b56-bba1-a37ccb680902">
++        <disable-for parent="C0525b8d8-e0e2-43b4-81d5-897a6553c8ac"/>
++    </modifier>
+ </alignment>

--- a/projects/lc-manual.halex
+++ b/projects/lc-manual.halex
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<hale-project version="5.1.0.release">
+<hale-project version="5.3.0.release">
     <name>[Annex II] AdV ALKIS 7.1.2 zu INSPIRE Land Cover</name>
     <author>Johanna Ott</author>
     <description>Transformationsprojekt für die Transformation von Daten aus ALKIS nach INSPIRE LandCover.&#13;
@@ -12,7 +12,7 @@ Hinweis zur Nutzung der Projektvariablen:&#13;
 	LANDCOVER_DATASET: id des LandCoverDatasets --&gt; kann nach Wunsch verändert werden&#13;
 	INSPIRE_NAMESPACE: gewünschten Namespace eingeben</description>
     <created>2018-02-21T09:31:57.934+01:00</created>
-    <modified>2024-04-25T16:31:13.819+02:00</modified>
+    <modified>2024-09-11T11:22:27.662+02:00</modified>
     <save-config provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
         <setting name="charset">UTF-8</setting>
         <setting name="projectFiles.separate">false</setting>

--- a/projects/lc-manual.halex.alignment.xml
+++ b/projects/lc-manual.halex.alignment.xml
@@ -14046,4 +14046,7 @@ return targeom
         </target>
         <parameter value="other:unpopulated" name="value"/>
     </cell>
+    <modifier cell="C291e909f-6406-4b56-bba1-a37ccb680902">
+        <disable-for parent="C0525b8d8-e0e2-43b4-81d5-897a6553c8ac"/>
+    </modifier>
 </alignment>

--- a/projects/lc-manual.md
+++ b/projects/lc-manual.md
@@ -1,0 +1,4 @@
+Notizen zu manuellen Anpassungen
+--------------------------------
+
+- Befüllung von `LandCoverDataset.member` deaktiviert, da das Feature sonst zu groß für die Weiterverarbeitung wird


### PR DESCRIPTION
Disable the generation of `LandCoverDataSet.member` because otherwise the feature becomes too large to process.